### PR TITLE
Fix health facility pricelist filter exception

### DIFF
--- a/src/pickers/ItemPicker.js
+++ b/src/pickers/ItemPicker.js
@@ -47,7 +47,7 @@ class ItemPicker extends Component {
         } = this.props;
         if (!this.props.items) return null;
         let items = [...this.props.items]
-        if (!!filteredOnPriceList && !!itemsPricelists) {
+        if (!!filteredOnPriceList && !!itemsPricelists && (filteredOnPriceList in itemsPricelists)) {
             items = items.filter(i => itemsPricelists[filteredOnPriceList][decodeId(i.id)] !== undefined)
         }
         return <AutoSuggestion

--- a/src/pickers/ServicePicker.js
+++ b/src/pickers/ServicePicker.js
@@ -48,7 +48,7 @@ class ServicePicker extends Component {
         } = this.props;
         if (!this.props.services) return null;
         let services = [...this.props.services]
-        if (!!filteredOnPriceList && !!servicesPricelists) {
+        if (!!filteredOnPriceList && !!servicesPricelists && (filteredOnPriceList in servicesPricelists)) {
             services = services.filter(i => servicesPricelists[filteredOnPriceList][decodeId(i.id)] !== undefined)
         }
         return <AutoSuggestion


### PR DESCRIPTION
Sometimes, when moving from the health facility claim search to a specific claim via double click, an error related to the price list occurs (for both items and services). PR solves this issue.

#### Reproducing steps (develop):
From the main view go to Claims -> Health Facility Claims menu
Open claim CID00001 by double clicking
Go back via the  < button next to claim name
Open claim CIB0001 by double clicking

#### Exception: 
![image](https://user-images.githubusercontent.com/32633751/108090222-ab77ac80-707a-11eb-832a-f65e88a71a78.png)
