### PR TITLE
OTC-884: Disabled save button in medical services/items fix

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -254,6 +254,12 @@ export function medicalServicesValidationCheck(mm, variables) {
   );
 }
 
+export function medicalServicesSetValid() {
+  return (dispatch) => {
+    dispatch({ type: `SERVICES_FIELDS_VALIDATION_SET_VALID` });
+  };
+}
+
 export function medicalServicesValidationClear() {
   return (dispatch) => {
     dispatch({ type: `SERVICES_FIELDS_VALIDATION_CLEAR` });
@@ -270,6 +276,12 @@ export function medicalItemsValidationCheck(mm, variables) {
     variables,
     `ITEMS_FIELDS_VALIDATION`,
   );
+}
+
+export function medicalItemsSetValid() {
+  return (dispatch) => {
+    dispatch({ type: `ITEMS_FIELDS_VALIDATION_SET_VALID` });
+  };
 }
 
 export function medicalItemsValidationClear() {

--- a/src/components/MedicalItemMasterPanel.js
+++ b/src/components/MedicalItemMasterPanel.js
@@ -15,7 +15,7 @@ import {
   withHistory,
   withModulesManager,
 } from "@openimis/fe-core";
-import { medicalItemsValidationCheck, medicalItemsValidationClear } from "../actions";
+import { medicalItemsValidationCheck, medicalItemsValidationClear, medicalItemsSetValid } from "../actions";
 import { ITEM_CODE_MAX_LENGTH } from "../constants";
 
 const styles = (theme) => ({
@@ -41,6 +41,7 @@ class MedicalItemMasterPanel extends FormPanel {
             <ValidatedTextInput
               action={medicalItemsValidationCheck}
               clearAction={medicalItemsValidationClear}
+              setValidAction={medicalItemsSetValid}
               itemQueryIdentifier="itemCode"
               isValid={isItemValid}
               isValidating={isItemValidating}

--- a/src/components/MedicalServiceMasterPanel.js
+++ b/src/components/MedicalServiceMasterPanel.js
@@ -15,7 +15,7 @@ import {
   withHistory,
   withModulesManager,
 } from "@openimis/fe-core";
-import { medicalServicesValidationCheck, medicalServicesValidationClear } from "../actions";
+import { medicalServicesValidationCheck, medicalServicesValidationClear, medicalServicesSetValid } from "../actions";
 import { SERVICE_CODE_MAX_LENGTH } from "../constants";
 
 const styles = (theme) => ({
@@ -41,6 +41,7 @@ class MedicalServiceMasterPanel extends FormPanel {
             <ValidatedTextInput
               action={medicalServicesValidationCheck}
               clearAction={medicalServicesValidationClear}
+              setValidAction={medicalServicesSetValid}
               itemQueryIdentifier="serviceCode"
               isValid={isServiceValid}
               isValidating={isServiceValidating}

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -231,6 +231,18 @@ function reducer(
           },
         },
       };
+    case "SERVICES_FIELDS_VALIDATION_SET_VALID":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          medicalService: {
+            isValidating: false,
+            isValid: true,
+            validationError: null,
+          },
+        },
+      };
     case "ITEMS_FIELDS_VALIDATION_REQ":
       return {
         ...state,
@@ -275,6 +287,18 @@ function reducer(
           medicalItem: {
             isValidating: true,
             isValid: false,
+            validationError: null,
+          },
+        },
+      };
+    case "ITEMS_FIELDS_VALIDATION_SET_VALID":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          medicalItem: {
+            isValidating: false,
+            isValid: true,
             validationError: null,
           },
         },


### PR DESCRIPTION
[OTC-884](https://openimis.atlassian.net/browse/OTC-884)

In scope of this ticket, I corrected the state of isValid by adding an extra action, which sets the state properly when we're editing a name of service/item for the first time. Moreover, there was an issue when we paste an invalid name and then revert it using CTRL+Z to the valid one, save button was anyway blocked although saving should be possbile. After the fix, it works as intended.

[OTC-884]: https://openimis.atlassian.net/browse/OTC-884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ