### PR TITLE
OTC-1106: allow to open historical content without system errors

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -193,7 +193,7 @@ export function deleteMedicalItem(mm, medicalItem, clientMutationLabel) {
 export function fetchMedicalService(mm, medicalServiceId, clientMutationId) {
   const filters = [];
   if (medicalServiceId) {
-    filters.push(`uuid: "${formatGQLString(medicalServiceId)}"`);
+    filters.push(`uuid: "${formatGQLString(medicalServiceId)}", showHistory: true`);
   } else if (clientMutationId) {
     filters.push(`clientMutationId: "${formatGQLString(clientMutationId)}"`);
   }
@@ -204,7 +204,7 @@ export function fetchMedicalService(mm, medicalServiceId, clientMutationId) {
 export function fetchMedicalItem(mm, medicalItemId, clientMutationId) {
   const filters = [];
   if (medicalItemId) {
-    filters.push(`uuid: "${formatGQLString(medicalItemId)}"`);
+    filters.push(`uuid: "${formatGQLString(medicalItemId)}", showHistory: true`);
   } else if (clientMutationId) {
     filters.push(`clientMutationId: "${formatGQLString(clientMutationId)}"`);
   }

--- a/src/components/MedicalItemForm.js
+++ b/src/components/MedicalItemForm.js
@@ -143,6 +143,7 @@ class MedicalItemForm extends Component {
     this.state.medicalItem.type &&
     this.state.medicalItem.price &&
     this.state.medicalItem.careType &&
+    !this.state.medicalItem.validityTo &&
     this.props.isItemValid;
 
   save = (medicalItem) => {
@@ -190,8 +191,9 @@ class MedicalItemForm extends Component {
         onlyIfDirty: !readOnly && !runningMutation,
       },
     ];
+    const shouldBeLocked = runningMutation || medicalItem?.validityTo;
     return (
-      <div className={runningMutation ? classes.lockedPage : null}>
+      <div className={shouldBeLocked ? classes.lockedPage : null}>
         <Helmet title={formatMessageWithValues(this.props.intl, "medical.item", "MedicalItemOverview.title")} />
         <ProgressOrError progress={fetchingMedicalItem} error={errorMedicalItem} />
         <ErrorBoundary>

--- a/src/components/MedicalServiceForm.js
+++ b/src/components/MedicalServiceForm.js
@@ -143,6 +143,7 @@ class MedicalServiceForm extends Component {
     this.state.medicalService.level &&
     this.state.medicalService.price &&
     this.state.medicalService.careType &&
+    !this.state.medicalService.validityTo &&
     this.props.isServiceValid;
 
   save = (medicalService) => {
@@ -183,8 +184,9 @@ class MedicalServiceForm extends Component {
         onlyIfDirty: !readOnly,
       },
     ];
+    const shouldBeLocked = lockNew || medicalService?.validityTo;
     return (
-      <div className={lockNew ? classes.lockedPage : null}>
+      <div className={shouldBeLocked ? classes.lockedPage : null}>
         <Helmet title={formatMessageWithValues(this.props.intl, "medical.service", "MedicalServiceOverview.title")} />
         <ProgressOrError progress={fetchingMedicalService} error={errorMedicalService} />
         <ErrorBoundary>


### PR DESCRIPTION
[OTC-1106](https://openimis.atlassian.net/browse/OTC-1106)

Changes:
- Add _showHistory_ to fetchMedicalItem/fetchMedicalService to allow fetching historical data.
- If historical content opened, display specific page style.
- Made saving historical forms impossible.

[OTC-1106]: https://openimis.atlassian.net/browse/OTC-1106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ