### PR TITLE
OP-1817: hide validity dates if historical data not requested

### DIFF
--- a/src/components/MedicalItemSearcher.js
+++ b/src/components/MedicalItemSearcher.js
@@ -69,7 +69,7 @@ class MedicalItemSearcher extends Component {
     return prms;
   };
 
-  headers = () => {
+  headers = (filters) => {
     const h = [
       "medical.item.code",
       "medical.item.name",
@@ -77,21 +77,21 @@ class MedicalItemSearcher extends Component {
       "medical.item.package",
       "medical.item.quantity",
       "medical.item.price",
-      "medical.item.validFrom",
-      "medical.item.validTo",
+      filters?.showHistory?.value ? "medical.item.validFrom" : null,
+      filters?.showHistory?.value ? "medical.item.validTo" : null,
     ];
     return h;
   };
 
-  sorts = () => [
+  sorts = (filters) => [
     ["code", true],
     ["name", true],
     ["type", true],
     ["package", true],
     ["quantity", false],
     ["price", true],
-    ["validityFrom", false],
-    ["validityTo", false],
+    filters?.showHistory?.value ? ["validityFrom", false] : null,
+    filters?.showHistory?.value ? ["validityTo", false] : null,
   ];
 
   deleteItem = () => {
@@ -120,7 +120,7 @@ class MedicalItemSearcher extends Component {
     );
   };
 
-  itemFormatters = () => {
+  itemFormatters = (filters) => {
     const formatters = [
       (ms) => ms.code,
       (ms) => ms.name,
@@ -128,8 +128,14 @@ class MedicalItemSearcher extends Component {
       (ms) => ms.package,
       (ms) => ms.quantity,
       (ms) => ms.price,
-      (ms) => formatDateFromISO(this.props.modulesManager, this.props.intl, ms.validityFrom),
-      (ms) => formatDateFromISO(this.props.modulesManager, this.props.intl, ms.validityTo),
+      (ms) =>
+        filters?.showHistory?.value
+          ? formatDateFromISO(this.props.modulesManager, this.props.intl, ms.validityFrom)
+          : null,
+      (ms) =>
+        filters?.showHistory?.value
+          ? formatDateFromISO(this.props.modulesManager, this.props.intl, ms.validityTo)
+          : null,
       (ms) => (
         <Tooltip title={formatMessage(this.props.intl, "medical.item", "openNewTab")}>
           <IconButton onClick={(e) => this.props.onDoubleClick(ms, true)}>

--- a/src/components/MedicalServiceSearcher.js
+++ b/src/components/MedicalServiceSearcher.js
@@ -65,27 +65,27 @@ class MedicalServiceSearcher extends Component {
     return prms;
   };
 
-  headers = () => {
+  headers = (filters) => {
     const h = [
       "medical.service.code",
       "medical.service.name",
       "medical.service.type",
       "medical.service.level",
       "medical.service.price",
-      "medical.service.validFrom",
-      "medical.service.validTo",
+      filters?.showHistory?.value ? "medical.service.validFrom" : null,
+      filters?.showHistory?.value ? "medical.service.validTo" : null,
     ];
     return h;
   };
 
-  sorts = () => [
+  sorts = (filters) => [
     ["code", true],
     ["name", true],
     ["type", true],
     ["level", true],
     ["price", true],
-    ["validityFrom", false],
-    ["validityTo", false],
+    filters?.showHistory?.value ? ["validityFrom", false] : null,
+    filters?.showHistory?.value ? ["validityTo", false] : null,
   ];
 
   deleteService = () => {
@@ -114,15 +114,21 @@ class MedicalServiceSearcher extends Component {
     );
   };
 
-  itemFormatters = () => {
+  itemFormatters = (filters) => {
     const formatters = [
       (ms) => ms.code,
       (ms) => ms.name,
       (ms) => ms.type,
       (ms) => ms.level,
       (ms) => ms.price,
-      (ms) => formatDateFromISO(this.props.modulesManager, this.props.intl, ms.validityFrom),
-      (ms) => formatDateFromISO(this.props.modulesManager, this.props.intl, ms.validityTo),
+      (ms) =>
+        filters?.showHistory?.value
+          ? formatDateFromISO(this.props.modulesManager, this.props.intl, ms.validityFrom)
+          : null,
+      (ms) =>
+        filters?.showHistory?.value
+          ? formatDateFromISO(this.props.modulesManager, this.props.intl, ms.validityTo)
+          : null,
       (ms) => (
         <Tooltip title={formatMessage(this.props.intl, "medical.service", "openNewTab")}>
           <IconButton onClick={(e) => this.props.onDoubleClick(ms, true)}>


### PR DESCRIPTION
[OP-1817](https://openimis.atlassian.net/browse/OP-1817)

Changes:

- MedicalItemSearcher | MedicalServiceSearcher : Show or hide "Validity From" and "Validity To" columns based on the showHistory filter.

[OP-1817]: https://openimis.atlassian.net/browse/OP-1817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ