### PR TITLE
Ajuster le code FE pour mise en place d'une version generique basé sur une variable de configuration

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -22,8 +22,8 @@ export const ITEM_TYPE_DRUG = "D";
 export const ITEM_TYPE_MEDICAL_CONSUMABLE = "M";
 export const ITEM_TYPES = [ITEM_TYPE_DRUG, ITEM_TYPE_MEDICAL_CONSUMABLE];
 
-export const SERVICE_CODE_MAX_LENGTH = 6;
-export const ITEM_CODE_MAX_LENGTH = 6;
+export const SERVICE_CODE_MAX_LENGTH = 50;
+export const ITEM_CODE_MAX_LENGTH = 50;
 
 export const SERVICE_CATEGORY_SURGERY = "S";
 export const SERVICE_CATEGORY_DELIVERY = "D";

--- a/src/constants.js
+++ b/src/constants.js
@@ -22,8 +22,8 @@ export const ITEM_TYPE_DRUG = "D";
 export const ITEM_TYPE_MEDICAL_CONSUMABLE = "M";
 export const ITEM_TYPES = [ITEM_TYPE_DRUG, ITEM_TYPE_MEDICAL_CONSUMABLE];
 
-export const SERVICE_CODE_MAX_LENGTH = 50;
-export const ITEM_CODE_MAX_LENGTH = 50;
+export const SERVICE_CODE_MAX_LENGTH = 20;
+export const ITEM_CODE_MAX_LENGTH = 20;
 
 export const SERVICE_CATEGORY_SURGERY = "S";
 export const SERVICE_CATEGORY_DELIVERY = "D";


### PR DESCRIPTION

Nous avons ajusté le fichier constants.js du front-end pour étendre le nombre de caractères autorisés pour l'ItemCode et le ServCode, passant de 6 à 20 caractères