### PR TITLE
fix: remove stale fetchMedicalServices import from child panels

### DIFF
--- a/src/components/MedicalItemChildPanel.js
+++ b/src/components/MedicalItemChildPanel.js
@@ -18,7 +18,7 @@ import {
 } from "@openimis/fe-core";
 import { Paper, Box } from "@material-ui/core";
 import _ from "lodash";
-import { fetchMedicalService, fetchMedicalServices } from "../actions"
+import { fetchMedicalService } from "../actions"
 
 import { claimedAmount, approvedAmount } from "../helpers/amounts";
 

--- a/src/components/MedicalServiceChildPanel.js
+++ b/src/components/MedicalServiceChildPanel.js
@@ -18,7 +18,7 @@ import {
 } from "@openimis/fe-core";
 import { Paper, Box } from "@material-ui/core";
 import _ from "lodash";
-import { fetchMedicalService, fetchMedicalServices } from "../actions"
+import { fetchMedicalService } from "../actions"
 
 const styles = (theme) => ({
   paper: theme.paper.paper,


### PR DESCRIPTION
# Description

`MedicalServiceChildPanel` and `MedicalItemChildPanel` both imported `fetchMedicalServices` from `../actions`, but this function does not exist in the actions module (the correct exports are `fetchMedicalService` and `fetchMedicalServicesSummaries`. The stale import caused a rollup build warning (`Import of non-existent exports`) on every build and would surface as a runtime error if the function were ever invoked.

The unused import has been removed from both components.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
