### PR TITLE
hide actions button in searcher

### DIFF
--- a/src/components/MedicalItemSearcher.jsx
+++ b/src/components/MedicalItemSearcher.jsx
@@ -2,9 +2,7 @@ import React, { Component } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
-import { GetIconComponent, ActionMenu } from "@openimis/fe-core";
-const TabIcon = GetIconComponent("Tab")
-const DeleteIcon = GetIconComponent("Delete")
+
 
 import {
   withModulesManager,
@@ -13,7 +11,11 @@ import {
   Searcher,
   journalize,
   formatDateFromISO,
+  GetIconComponent,
+  ActionMenu,
 } from "@openimis/fe-core";
+const TabIcon = GetIconComponent("Tab")
+const DeleteIcon = GetIconComponent("Delete")
 
 import { fetchMedicalItemsSummaries, deleteMedicalItem } from "../actions";
 import { RIGHT_MEDICALITEMS_DELETE } from "../constants";

--- a/src/components/MedicalItemSearcher.jsx
+++ b/src/components/MedicalItemSearcher.jsx
@@ -2,8 +2,7 @@ import React, { Component } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
-import { Button, Tooltip } from "@mui/material";
-import { GetIconComponent } from "@openimis/fe-core";
+import { GetIconComponent, ActionMenu } from "@openimis/fe-core";
 const TabIcon = GetIconComponent("Tab")
 const DeleteIcon = GetIconComponent("Delete")
 
@@ -113,18 +112,6 @@ class MedicalItemSearcher extends Component {
     this.setState({ deleteItem: deletedItem });
   };
 
-  deleteAction = (i) => {
-    return !!i.validityTo || !!i.clientMutationId ? null : (
-      <Tooltip title={formatMessage(this.props.intl, "medical.item", "deleteService.tooltip")}>
-        <Button onClick={(e) => this.confirmDelete(i)}
-          startIcon={<DeleteIcon />}
-        >
-          {formatMessage(this.props.intl, "medical.service", "deleteServiceButton.buttonText")}
-        </Button>
-      </Tooltip>
-    );
-  };
-
   itemFormatters = (filters) => {
     const formatters = [
       (ms) => ms.code,
@@ -142,19 +129,25 @@ class MedicalItemSearcher extends Component {
           ? formatDateFromISO(this.props.modulesManager, this.props.intl, ms.validityTo)
           : null,
       (ms) => (
-        <Tooltip title={formatMessage(this.props.intl, "medical.item", "openNewTab")}>
-          <Button onClick={(e) => this.props.onDoubleClick(ms, true)}
-            startIcon={<TabIcon />}
-          >
-            {formatMessage(this.props.intl, "medical.item", "openNewTabButton.buttonText")}
-          </Button>
-        </Tooltip>
+        <ActionMenu
+          actions={[
+            {
+              icon: <TabIcon  fontSize="small"/>,
+              label: formatMessage(this.props.intl, "medical.item", "openNewTabButton.buttonText"),
+              tooltip: formatMessage(this.props.intl, "medical.item", "openNewTab"),
+              onClick: () => this.props.onDoubleClick(ms, true)
+            },
+            this.props.rights.includes(RIGHT_MEDICALITEMS_DELETE) && (!ms.validityTo || !!ms.clientMutationId) && {
+              divider: true,
+              icon: <DeleteIcon fontSize="small" />,
+              label: formatMessage(this.props.intl, "medical.service", "deleteServiceButton.buttonText"),
+              tooltip: formatMessage(this.props.intl, "medical.item", "deleteService.tooltip"),
+              onClick: () => this.confirmDelete(ms)
+            }
+          ].filter(Boolean)}
+        />
       ),
     ];
-
-    if (this.props.rights.includes(RIGHT_MEDICALITEMS_DELETE)) {
-      formatters.push(this.deleteAction);
-    }
     return formatters;
   };
 

--- a/src/components/MedicalServiceSearcher.jsx
+++ b/src/components/MedicalServiceSearcher.jsx
@@ -2,8 +2,7 @@ import React, { Component } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
-import { Button, Tooltip } from "@mui/material";
-import { GetIconComponent } from "@openimis/fe-core";
+import { GetIconComponent, ActionMenu } from "@openimis/fe-core";
 const TabIcon = GetIconComponent("Tab")
 const DeleteIcon = GetIconComponent("Delete")
 
@@ -109,16 +108,6 @@ class MedicalServiceSearcher extends Component {
     this.setState({ deleteService: deletedService });
   };
 
-  deleteAction = (i) => {
-    return !!i.validityTo || !!i.clientMutationId ? null : (
-      <Tooltip title={formatMessage(this.props.intl, "medical.service", "deleteService.tooltip")}>
-        <Button onClick={(e) => this.confirmDelete(i)} startIcon={<DeleteIcon />}>
-          {formatMessage(this.props.intl, "medical.service", "deleteServiceButton.buttonText")}
-        </Button>
-      </Tooltip>
-    );
-  };
-
   itemFormatters = (filters) => {
     const formatters = [
       (ms) => ms.code,
@@ -136,17 +125,26 @@ class MedicalServiceSearcher extends Component {
           ? formatDateFromISO(this.props.modulesManager, this.props.intl, ms.validityTo)
           : null,
       (ms) => (
-        <Tooltip title={formatMessage(this.props.intl, "medical.service", "openNewTab")}>
-          <Button onClick={(e) => this.props.onDoubleClick(ms, true)} startIcon={<TabIcon />}>
-            {formatMessage(this.props.intl, "medical.service", "openNewTabButton.buttonText")}
-          </Button>
-        </Tooltip>
+        <ActionMenu
+          actions={[
+            {
+              icon: <TabIcon fontSize="small"/>,
+              label: formatMessage(this.props.intl, "medical.service", "openNewTabButton.buttonText"),
+              onClick: () => this.props.onDoubleClick(ms, true),
+              tooltip: formatMessage(this.props.intl, "medical.service", "openNewTab")
+            },
+            this.props.rights.includes(RIGHT_MEDICALSERVICES_DELETE) && (!ms.validityTo || !ms.clientMutationId) && {
+              divider: true,
+              icon: <DeleteIcon fontSize="small" color="error"/>,
+              label: formatMessage(this.props.intl, "medical.service", "deleteServiceButton.buttonText"),
+              onClick: () => this.confirmDelete(ms),
+              tooltip: formatMessage(this.props.intl, "medical.service", "deleteService.tooltip")
+            }
+          ].filter(Boolean)}
+        />
+        
       ),
     ];
-
-    if (this.props.rights.includes(RIGHT_MEDICALSERVICES_DELETE)) {
-      formatters.push(this.deleteAction);
-    }
     return formatters;
   };
 

--- a/src/components/MedicalServiceSearcher.jsx
+++ b/src/components/MedicalServiceSearcher.jsx
@@ -2,10 +2,6 @@ import React, { Component } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
-import { GetIconComponent, ActionMenu } from "@openimis/fe-core";
-const TabIcon = GetIconComponent("Tab")
-const DeleteIcon = GetIconComponent("Delete")
-
 import {
   withModulesManager,
   formatMessageWithValues,
@@ -13,7 +9,11 @@ import {
   Searcher,
   journalize,
   formatDateFromISO,
+  ActionMenu,
+  GetIconComponent,
 } from "@openimis/fe-core";
+const TabIcon = GetIconComponent("Tab")
+const DeleteIcon = GetIconComponent("Delete")
 
 import { fetchMedicalServicesSummaries, deleteMedicalService } from "../actions";
 import { RIGHT_MEDICALSERVICES_DELETE } from "../constants";


### PR DESCRIPTION
# Description

Hide the action buttons in the list to free up space and improve the table layout

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [x] Requires [https://github.com/openimis/openimis-fe-core_js/pull/342], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="1409" height="552" alt="Screenshot 2026-07-31 at 5 19 53 PM" src="https://github.com/user-attachments/assets/eb1cc26f-9358-4727-b87a-173e56107012" />
<img width="1420" height="305" alt="Screenshot 2026-07-31 at 5 29 46 PM" src="https://github.com/user-attachments/assets/d74f6e5c-b33b-4dfa-a881-fa9fe00c2934" />


## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
